### PR TITLE
Migrate to value-based SwiftUI navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ xcodebuild -project RickAndMorty-SwiftUI.xcodeproj \
 ### Search & Cancellation
 
 - **`.searchable` + `onChange`**: Native SwiftUI integration with `NavigationStack`. The search bar appears idiomatically and the binding drives the entire search flow.
+- **Value-based navigation**: `NavigationLink(value:)` with `.navigationDestination(for:)` for lazy destination creation and decoupled navigation, replacing the legacy `NavigationLink(destination:)` pattern.
 - **Debounce (300ms)**: Each keystroke cancels the previous `Task` and starts a new one with a `Task.sleep` guard. This avoids firing a network request per character typed.
 - **Task cancellation**: `searchTask?.cancel()` before creating each new `Task` ensures in-flight URLSession requests are cancelled. A `guard !Task.isCancelled` check after the debounce and after the network call prevents stale results from appearing.
 - **Empty state**: `ContentUnavailableView` (iOS 17+) provides a native empty-results screen with system imagery.

--- a/RickAndMorty-SwiftUI/RickAndMorty-SwiftUI/UI/CharacterListView.swift
+++ b/RickAndMorty-SwiftUI/RickAndMorty-SwiftUI/UI/CharacterListView.swift
@@ -35,7 +35,7 @@ struct CharacterListView: View {
                 } else {
                     if typeList == .list {
                         List(viewModel.characters) { character in
-                            NavigationLink(destination: createCharacterDetailView.create(character: character)) {
+                            NavigationLink(value: character) {
                                 CharacterListItemView(character: character,
                                                       downloadImageUseCase: viewModel.downloadImageUseCase)
                             }
@@ -44,7 +44,7 @@ struct CharacterListView: View {
                         ScrollView {
                             LazyVGrid(columns: [gridItem]) {
                                 ForEach(viewModel.characters) { character in
-                                    NavigationLink(destination: createCharacterDetailView.create(character: character)) {
+                                    NavigationLink(value: character) {
                                         CharacterGridItemView(character: character,
                                                               downloadImageUseCase: viewModel.downloadImageUseCase)
                                     }
@@ -62,6 +62,9 @@ struct CharacterListView: View {
             }
             .toolbar {
                 CharacterListTypeSwitcherView(typeList: $typeList)
+            }
+            .navigationDestination(for: CharacterPresentable.self) { character in
+                createCharacterDetailView.create(character: character)
             }
         }
         .task {


### PR DESCRIPTION
 # Summary

  - Replace legacy NavigationLink(destination:) with NavigationLink(value:) + .navigationDestination(for:) in CharacterListView
  - Destination views are now created lazily (only when navigating) instead of eagerly on list render
  - Update README to document the value-based navigation pattern

#  Test plan

  - Navigate to character detail from list view
  - Navigate to character detail from grid view
  - Verify back gesture works correctly
  - Search a character and navigate to its detail
  - Run full test suite